### PR TITLE
Fix command keyboard actions

### DIFF
--- a/src/bot_handler/callback_actions.rs
+++ b/src/bot_handler/callback_actions.rs
@@ -10,4 +10,9 @@ pub enum CallbackAction<'a> {
     TL(&'a str, &'a str),
     BackToRepoDetails(&'a str),
     BackToRepoList,
+    // Command keyboard actions, should be handled as commands:
+    Help,
+    List,
+    Add,
+    Remove,
 }

--- a/src/bot_handler/mod.rs
+++ b/src/bot_handler/mod.rs
@@ -117,7 +117,11 @@ impl BotHandler {
         Ok(())
     }
 
-    pub async fn handle_callback_query(&self, query: &CallbackQuery, dialogue: Dialogue<CommandState, InMemStorage<CommandState>>) -> BotHandlerResult<()> {
+    pub async fn handle_callback_query(
+        &self,
+        query: &CallbackQuery,
+        dialogue: Dialogue<CommandState, InMemStorage<CommandState>>,
+    ) -> BotHandlerResult<()> {
         let query_id = query.id.clone();
 
         if let Some(data_str) = &query.data.as_deref() {
@@ -149,11 +153,9 @@ impl BotHandler {
                 }
                 // Handle commands like Help, List, Add, Remove
                 command_action => {
-                    let msg = query
-                        .message
-                        .as_ref()
-                        .and_then(|m| m.regular_message())
-                        .ok_or(BotHandlerError::InvalidInput("Callback query has no message".to_string()))?;
+                    let msg = query.message.as_ref().and_then(|m| m.regular_message()).ok_or(
+                        BotHandlerError::InvalidInput("Callback query has no message".to_string()),
+                    )?;
 
                     let cmd = match command_action {
                         CallbackAction::Help => Command::Help,

--- a/src/bot_handler/mod.rs
+++ b/src/bot_handler/mod.rs
@@ -117,7 +117,7 @@ impl BotHandler {
         Ok(())
     }
 
-    pub async fn handle_callback_query(&self, query: &CallbackQuery) -> BotHandlerResult<()> {
+    pub async fn handle_callback_query(&self, query: &CallbackQuery, dialogue: Dialogue<CommandState, InMemStorage<CommandState>>) -> BotHandlerResult<()> {
         let query_id = query.id.clone();
 
         if let Some(data_str) = &query.data.as_deref() {
@@ -146,6 +146,24 @@ impl BotHandler {
                 }
                 CallbackAction::BackToRepoList => {
                     self.action_back_to_repo_list(query).await?;
+                }
+                // Handle commands like Help, List, Add, Remove
+                command_action => {
+                    let msg = query
+                        .message
+                        .as_ref()
+                        .and_then(|m| m.regular_message())
+                        .ok_or(BotHandlerError::InvalidInput("Callback query has no message".to_string()))?;
+
+                    let cmd = match command_action {
+                        CallbackAction::Help => Command::Help,
+                        CallbackAction::List => Command::List,
+                        CallbackAction::Add => Command::Add,
+                        CallbackAction::Remove => Command::Remove,
+                        _ => unreachable!(),
+                    };
+
+                    self.handle_commands(msg, cmd, dialogue).await?;
                 }
             }
         } else {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -65,9 +65,9 @@ impl BotDispatcher {
     fn build_callback_queries_branch(&self) -> DispatchHandler {
         Update::filter_callback_query().chain(filter_map(extract_dialogue)).endpoint(
             |query: CallbackQuery,
-             _dialogue: Dialogue<CommandState, InMemStorage<CommandState>>,
+             dialogue: Dialogue<CommandState, InMemStorage<CommandState>>,
              handler: Arc<BotHandler>| async move {
-                handler.handle_callback_query(&query).await
+                handler.handle_callback_query(&query, dialogue).await
             },
         )
     }

--- a/src/github/github.graphql
+++ b/src/github/github.graphql
@@ -21,7 +21,7 @@ query Issues($owner: String!, $name: String!, $labels: [String!], $first: Int = 
 
 query Labels($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
-    labels(first: 100, orderBy: { field: CREATED_AT, direction: ASC }) {
+    labels(first: 100) {
       nodes {
         name
         color

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -541,12 +541,12 @@ fn build_repo_labels_keyboard(
 lazy_static! {
     static ref COMMAND_KEYBOARD: InlineKeyboardMarkup = InlineKeyboardMarkup::new(vec![
         vec![
-            InlineKeyboardButton::callback("Help", "help"),
-            InlineKeyboardButton::callback("List", "list"),
+            InlineKeyboardButton::callback("Help", utils::serialize_action(&CallbackAction::Help)),
+            InlineKeyboardButton::callback("List", utils::serialize_action(&CallbackAction::List)),
         ],
         vec![
-            InlineKeyboardButton::callback("Add", "add"),
-            InlineKeyboardButton::callback("Remove", "remove"),
+            InlineKeyboardButton::callback("Add", utils::serialize_action(&CallbackAction::Add)),
+            InlineKeyboardButton::callback("Remove", utils::serialize_action(&CallbackAction::Remove)),
         ],
     ]);
 }

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -495,7 +495,6 @@ fn build_repo_item_keyboard(repo: &RepoEntity) -> InlineKeyboardMarkup {
             ),
         ],
         vec![
-            // TODO: go back should be edit message, not new message
             // Back to list button
             InlineKeyboardButton::callback("🔙 List".to_string(), back_to_list),
             // Manage repo labels button

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -546,7 +546,10 @@ lazy_static! {
         ],
         vec![
             InlineKeyboardButton::callback("Add", utils::serialize_action(&CallbackAction::Add)),
-            InlineKeyboardButton::callback("Remove", utils::serialize_action(&CallbackAction::Remove)),
+            InlineKeyboardButton::callback(
+                "Remove",
+                utils::serialize_action(&CallbackAction::Remove)
+            ),
         ],
     ]);
 }

--- a/src/messaging/utils.rs
+++ b/src/messaging/utils.rs
@@ -34,6 +34,7 @@ pub fn github_color_to_emoji(hex_color: &str) -> &str {
 }
 
 /// Serializes a `CallbackAction` to a JSON string. Used for keyboard buttons.
+/// expect is ok because inputs are simple and controlled.
 pub fn serialize_action(action: &CallbackAction) -> String {
     serde_json::to_string(action).expect("Failed to serialize action")
 }


### PR DESCRIPTION
Replace command keyboard callback string slice actions with `CallbackAction` enum variants to fix command keyboard